### PR TITLE
Disable signing for snapshot version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,6 +149,10 @@ tasks.withType(Test::class) {
     useJUnitPlatform()
 }
 
+tasks.withType<Sign>().configureEach {
+    onlyIf { !version.toString().endsWith("SNAPSHOT") }
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {


### PR DESCRIPTION
This allows users to run `publishToMavenLocal` so they can build the library and reference it in their projects locally